### PR TITLE
feat: add blueprint that catches no affiliation or job title on log in

### DIFF
--- a/ckanext/useraffiliation/actions.py
+++ b/ckanext/useraffiliation/actions.py
@@ -26,7 +26,7 @@ def _commit_plugin_extras(context):
         context['model'].Session.commit()
 
 
-def _check_plugin_extras_provided(data_dict):
+def check_plugin_extras_provided(data_dict):
     for field in CUSTOM_FIELDS:
         if field["name"] not in data_dict or data_dict.get(field["name"]) == '':
             raise toolkit.ValidationError(
@@ -71,7 +71,7 @@ def user_show(original_action, context, data_dict):
 
 @toolkit.chained_action
 def user_create(original_action, context, data_dict):
-    _check_plugin_extras_provided(data_dict)
+    check_plugin_extras_provided(data_dict)
 
     user = original_action(context, data_dict)
     user_obj = _get_user_obj(context)
@@ -89,7 +89,7 @@ def user_create(original_action, context, data_dict):
 @toolkit.chained_action
 def user_update(original_action, context, data_dict):
     toolkit.check_access("user_update", context, data_dict)
-    _check_plugin_extras_provided(data_dict)
+    check_plugin_extras_provided(data_dict)
 
     user = original_action(context, data_dict)
     user_obj = _get_user_obj(context)

--- a/ckanext/useraffiliation/blueprints.py
+++ b/ckanext/useraffiliation/blueprints.py
@@ -35,6 +35,8 @@ def check_user_affiliation():
     # if any of the above are false
     if not hasUserAffiliationFields or not hasJobTitle or not hasAffiliation:
         # redirect to user edit page
+        # with a flash error so the user know what to do
+        h.flash_error('Please complete your profile by adding your job title and affiliation.')
         return h.redirect_to(u'user.edit')
         
     # otherwise, carry on as normal (i.e. load the dashboard)
@@ -54,8 +56,9 @@ def get_route_to_intercept():
     if configured_route.endswith('.index'):
         configured_route = configured_route[:-6]
         
-    # add the leading slash and convert and periods to slashes
-    return '/' + configured_route.replace('.', '/')
+    # add the leading and trailing slashes
+    # and convert any internal periods to slashes
+    return '/' + configured_route.replace('.', '/') + '/'
 
 useraffiliation.add_url_rule(
     get_route_to_intercept(),

--- a/ckanext/useraffiliation/blueprints.py
+++ b/ckanext/useraffiliation/blueprints.py
@@ -1,0 +1,64 @@
+# encoding: utf-8
+from operator import index
+import ckan.lib.helpers as h
+from ckan.views.dashboard import index
+from ckan.common import _, config, g
+from flask import Blueprint
+import logging
+
+log = logging.getLogger(__name__)
+
+useraffiliation = Blueprint(
+    'useraffiliation',
+    __name__,
+)
+
+
+def check_user_affiliation():
+    """
+    Check if user profile has affiliation and job title, as defined by this plugin.
+    """
+    try:
+        # get user profile
+        user_profile = g.userobj
+    except:
+        # assume if this fails that the user is not logged in?
+        h.redirect_to(u'user.login')
+
+    # does user profile have the required plugin extras item?
+    hasUserAffiliationFields = 'useraffiliation' in user_profile.plugin_extras
+    # does user have a job title and is it a string with content?
+    hasJobTitle = 'job_title' in user_profile.plugin_extras.get('useraffiliation', {}) and user_profile.plugin_extras.get('useraffiliation', {}).get('job_title', '') != ''
+    # does user have an affiliation and is it a string with content?
+    hasAffiliation = 'affiliation' in user_profile.plugin_extras.get('useraffiliation', {}) and user_profile.plugin_extras.get('useraffiliation', {}).get('affiliation', '') != ''
+    
+    # if any of the above are false
+    if not hasUserAffiliationFields or not hasJobTitle or not hasAffiliation:
+        # redirect to user edit page
+        return h.redirect_to(u'user.edit')
+        
+    # otherwise, carry on as normal (i.e. load the dashboard)
+    # Note - this now ignores the ckan.route_after_login config setting, which is not ideal
+    return index()
+
+
+def get_route_to_intercept():
+    """
+    Get the route that should be intercepted
+    """
+    configured_route = config.get('ckan.route_after_login', 'dashboard.index')
+
+    # the default is dashboard.index
+    # however, and ".index"es will not get caught at, for example, "/dashboard/"
+    # so we remove any ending ".index"
+    if configured_route.endswith('.index'):
+        configured_route = configured_route[:-6]
+        
+    # add the leading slash and convert and periods to slashes
+    return '/' + configured_route.replace('.', '/')
+
+useraffiliation.add_url_rule(
+    get_route_to_intercept(),
+    view_func=check_user_affiliation,
+    methods=['GET']
+)

--- a/ckanext/useraffiliation/plugin.py
+++ b/ckanext/useraffiliation/plugin.py
@@ -6,7 +6,7 @@ import ckan.plugins as plugins
 from ckan.lib.plugins import DefaultTranslation
 from ckan.lib.plugins import DefaultPermissionLabels
 
-from ckanext.useraffiliation import actions
+from ckanext.useraffiliation import actions, blueprints
 
 log = logging.getLogger(__name__)
 
@@ -21,9 +21,9 @@ ALLOWED_ACTIONS = [
 class UserAffiliationPlugin(
     plugins.SingletonPlugin, DefaultTranslation, DefaultPermissionLabels
 ):
-    plugins.implements(plugins.IActions)
-    # plugins.implements(plugins.interfaces.IBlueprint)
     plugins.implements(plugins.IConfigurer)
+    plugins.implements(plugins.IBlueprint)
+    plugins.implements(plugins.IActions)
 
     # IConfigurer
 
@@ -40,3 +40,6 @@ class UserAffiliationPlugin(
         }
         return functions
         
+    # IBlueprint
+    def get_blueprint(self):
+        return blueprints.useraffiliation


### PR DESCRIPTION
This blueprint:

- catches CKAN when it goes to ckan.route_after_login (we know this happens after a successful login)
- intercepts that and runs check_user_affiliation(), which checks that the correct plugin_extras user dict exists and that it has the two new fields and that they aren't empty strings
- if any of those things, it redirects to user.edit with a flash error explaining what's gone wrong
- if the profile check outs fine it redirect explicitly to dashboard.index() (not /dashboard/ or ckan.route_after_login as this created infinite redirects)

#todo

I would like to be able to redirect to the original config rather than hard coding to dashboard.index... not sure how to do this though